### PR TITLE
Add new properties to TentPublicDto and mapping methods

### DIFF
--- a/Data/TentRepositorySupabase.cs
+++ b/Data/TentRepositorySupabase.cs
@@ -70,7 +70,13 @@ namespace Smart_Roots_Server.Data
         {
             MacAddress = e.GetProperty("mac_address").GetString()!,
             Name = e.TryGetProperty("name", out var n) ? n.GetString() : null,
-            Location = e.TryGetProperty("location", out var l) ? l.GetString() : null
+            Location = e.TryGetProperty("location", out var l) ? l.GetString() : null,
+            Country = e.TryGetProperty("country", out var c)? c.GetString():null,
+            OrganizationName = e.TryGetProperty("organization_name", out var o)? o.GetString() : null,
+            TentType = e.TryGetProperty("tent_type", out var t)? t.GetString() : null
+
+
+
         };
 
         // =========================================================
@@ -79,7 +85,7 @@ namespace Smart_Roots_Server.Data
         public async Task<IEnumerable<TentPublicDto>> GetAllPublicAsync(CancellationToken ct)
         {
             var c = DbClient(); // anon ok
-            var res = await c.GetAsync("tents?select=mac_address,name,location", ct);
+            var res = await c.GetAsync("tents?select=mac_address,name,location,tent_type,country,organization_name", ct);
             res.EnsureSuccessStatusCode();
             var txt = await res.Content.ReadAsStringAsync(ct);
             using var doc = JsonDocument.Parse(txt);
@@ -120,7 +126,7 @@ namespace Smart_Roots_Server.Data
                 Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json")
             };
             req.Headers.Add("Prefer", "return=minimal");
-
+            
             var res = await c.SendAsync(req, ct);
             if (res.IsSuccessStatusCode) return true;
             if ((int)res.StatusCode == 409) return false; // duplicate mac

--- a/Infrastructure/Dtos/TentPublicDto.cs
+++ b/Infrastructure/Dtos/TentPublicDto.cs
@@ -6,5 +6,9 @@
         public string MacAddress { get; set; } = default!;
         public string? Name { get; set; }
         public string? Location { get; set; }
+        public string Country { get; set; }
+        public string? TentType { get; set; }
+        public string? OrganizationName { get; set; }
+
     }
 }


### PR DESCRIPTION
Updated the `MapPublic` method in `TentRepositorySupabase.cs` to include `Country`, `OrganizationName`, and `TentType` in the mapping process. Modified the `GetAllPublicAsync` method to request these new properties from the API. Enhanced the `TentPublicDto` class to define the new properties, with `Country` as a non-nullable string and `TentType` and `OrganizationName` as nullable strings.