### PR TITLE
Update SensorStates and Validator for new properties

### DIFF
--- a/Infrastructure/Models/SensorStates.cs
+++ b/Infrastructure/Models/SensorStates.cs
@@ -1,16 +1,25 @@
 ﻿using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
+using System.ComponentModel;
 
 namespace Smart_Roots_Server.Infrastructure.Models {
     public class SensorStates {
 
-     
+        [DisplayName("fan")]
         public int Fan { get; set; }
-        public int EC { get; set; }
+        [DisplayName("ecUp")]
+        public int ECUp{ get; set; }
+        [DisplayName("ecDown")]
+        public int ECDown{ get; set; }
+        [DisplayName("pump")]
         public int Pump { get; set; }
-        public int PH { get; set; }
+        [DisplayName("pHUp")]
+        public int PHUp { get; set; }
+        [DisplayName("pHDown")]
+        public int PHDown { get; set; }
+        [DisplayName("light")]
         public int Light { get; set; }
+        [DisplayName("extractorFan")]
         public int ExtractorFan { get; set; }
-
     }
 }

--- a/Infrastructure/Validation/SensorStateValidator.cs
+++ b/Infrastructure/Validation/SensorStateValidator.cs
@@ -6,11 +6,14 @@ namespace Smart_Roots_Server.Infrastructure.Validation {
 
         public SensorStateValidator() {
       
-            RuleFor(s=>s.EC).GreaterThan(-1).LessThan(1400);
-            RuleFor(s => s.PH).GreaterThan(-14).LessThan(14);
+            RuleFor(s=>s.ECUp).GreaterThan(-1).LessThan(2);
+            RuleFor(s => s.ECDown).GreaterThan(-1).LessThan(2);
+            RuleFor(s => s.PHDown).GreaterThan(-1).LessThan(2);
             RuleFor(s => s.Pump).GreaterThan(-1).LessThan(2);
-            RuleFor(s => s.ExtractorFan).GreaterThan(-1).LessThan(101);
-            RuleFor(s => s.Fan).GreaterThan(-1).LessThan(100);
+            RuleFor(s => s.ExtractorFan).GreaterThan(-1).LessThan(2);
+            RuleFor(s => s.Fan).GreaterThan(-1).LessThan(2);
+            RuleFor(s=>s.ECUp).GreaterThan(-1).LessThan(2);
+            RuleFor(s=>s.Light).GreaterThan(-1).LessThan(2);
           
         }
     }


### PR DESCRIPTION
Modified the `SensorStates` class to add `ECUp`, `ECDown`, `PHUp`, and `PHDown` properties with `DisplayName` attributes, while removing the existing `EC` and `PH` properties. Updated the `SensorStateValidator` to include validation rules for the new properties and adjusted validation ranges for `Pump`, `ExtractorFan`, and `Fan`.