### PR TITLE
Update CORS policy to remove trailing slash in origin

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -23,7 +23,7 @@ namespace Smart_Roots_Server {
             builder.Services.AddCors(options => {
                 options.AddPolicy(name: MyAllowSpecificOrigins,
                                   policy => {
-                                     policy.WithOrigins("https://smart-roots-web.vercel.app/")
+                                     policy.WithOrigins("https://smart-roots-web.vercel.app")
                                       .AllowAnyHeader()
                                       .AllowAnyMethod()
                                       .AllowCredentials();


### PR DESCRIPTION
Modified the CORS policy in `Program.cs` to allow requests from "https://smart-roots-web.vercel.app" instead of "https://smart-roots-web.vercel.app/", ensuring better recognition of requests from the specified origin.